### PR TITLE
Fix typos in appdata

### DIFF
--- a/net.sourceforge.atanks.appdata.xml
+++ b/net.sourceforge.atanks.appdata.xml
@@ -10,9 +10,9 @@ SentUpstream: 2014-09-17
   <summary>Turn-based artillery strategy game</summary>
   <description>
     <p>
-      Atomic Tanks is a turn based artillery strategy game where opponents
+      Atomic Tanks is a turn-based artillery strategy game where opponents
       take turns to bombard each other with a wide array of different weapons.
-      To make things more interesting, Atomic Tanks also features desctructable
+      To make things more interesting, Atomic Tanks also features destructible
       landscapes, teleporting, parachutes and different weather conditions.
     </p>
   </description>


### PR DESCRIPTION
* "turn-based" is more conventional, eg
  https://en.wikipedia.org/wiki/Turn-based_strategy
* "desctructable" is not a word; nor is "destructable".
  https://en.wiktionary.org/wiki/destructible